### PR TITLE
ensure algolia uuid exists before attempting to index

### DIFF
--- a/src/Extensions/AlgoliaObjectExtension.php
+++ b/src/Extensions/AlgoliaObjectExtension.php
@@ -236,10 +236,14 @@ class AlgoliaObjectExtension extends DataExtension
     public function onBeforeWrite()
     {
         if (!$this->owner->AlgoliaUUID) {
-            $uuid = Uuid::uuid4();
-
-            $this->owner->AlgoliaUUID = $uuid->toString();
+            $this->owner->assignAlgoliaUUID();
         }
+    }
+
+    public function assignAlgoliaUUID()
+    {
+        $uuid = Uuid::uuid4();
+        $this->owner->AlgoliaUUID = $uuid->toString();
     }
 
     /**

--- a/src/Tasks/AlgoliaReindex.php
+++ b/src/Tasks/AlgoliaReindex.php
@@ -103,6 +103,11 @@ class AlgoliaReindex extends BuildTask
                     continue;
                 }
 
+                // Set AlgoliaUUID, in case it wasn't previously set
+                if (!$item->AlgoliaUUID) {
+                    $item->assignAlgoliaUUID();
+                }
+
                 $batchKey = get_class($item);
 
                 if (!isset($currentBatches[$batchKey])) {


### PR DESCRIPTION
@brynnb and I were working with this library and found that, after the UUID change was introduced, existing pages/objects weren't be assigned UUIDs, which prevented them from being indexed. This change assigns a UUID to the object if one doesn't already exist at the time of indexing.