### PR TITLE
persist uuid written at index time

### DIFF
--- a/src/Tasks/AlgoliaReindex.php
+++ b/src/Tasks/AlgoliaReindex.php
@@ -106,6 +106,7 @@ class AlgoliaReindex extends BuildTask
                 // Set AlgoliaUUID, in case it wasn't previously set
                 if (!$item->AlgoliaUUID) {
                     $item->assignAlgoliaUUID();
+                    $item->write();
                 }
 
                 $batchKey = get_class($item);


### PR DESCRIPTION
A small but crucial addition to #21. Make sure to write the UUID to the DB when it's assigned during the index task.