### PR TITLE
Pass class name to AlgoliaIndexer::deleteItem

### DIFF
--- a/src/Extensions/AlgoliaObjectExtension.php
+++ b/src/Extensions/AlgoliaObjectExtension.php
@@ -215,14 +215,14 @@ class AlgoliaObjectExtension extends DataExtension
         $indexer = Injector::inst()->get(AlgoliaIndexer::class);
 
         if ($this->config()->get('use_queued_indexing')) {
-            $indexDeleteJob = new AlgoliaDeleteItemJob($this->owner->AlgoliaUUID);
+            $indexDeleteJob = new AlgoliaDeleteItemJob($this->owner->getClassName(), $this->owner->AlgoliaUUID);
 
             QueuedJobService::singleton()->queueJob($indexDeleteJob);
 
             $this->markAsRemovedFromAlgoliaIndex();
         } else {
             try {
-                $indexer->deleteItem($this->owner->AlgoliaUUID);
+                $indexer->deleteItem($this->owner->getClassName(), $this->owner->AlgoliaUUID);
 
                 $this->markAsRemovedFromAlgoliaIndex();
             } catch (Exception $e) {

--- a/src/Jobs/AlgoliaDeleteItemJob.php
+++ b/src/Jobs/AlgoliaDeleteItemJob.php
@@ -18,13 +18,12 @@ class AlgoliaDeleteItemJob extends AbstractQueuedJob implements QueuedJob
 {
     /**
      * @param string $itemClass
-     * @param int    $itemId
+     * @param int    $itemUUID
      */
-    public function __construct($itemUUID)
+    public function __construct($itemClass, $itemUUID)
     {
-        if ($itemUUID) {
-            $this->itemUUID = $itemUUID;
-        }
+        $this->itemClass = $itemClass;
+        $this->itemUUID = $itemUUID;
     }
 
 
@@ -55,7 +54,7 @@ class AlgoliaDeleteItemJob extends AbstractQueuedJob implements QueuedJob
     {
         try {
             $indexer = Injector::inst()->create(AlgoliaIndexer::class);
-            $indexer->deleteItem($this->itemUUID);
+            $indexer->deleteItem($this->itemClass, $this->itemUUID);
         } catch (Exception $e) {
             Injector::inst()->create(LoggerInterface::class)->error($e);
         }

--- a/src/Service/AlgoliaIndexer.php
+++ b/src/Service/AlgoliaIndexer.php
@@ -257,10 +257,13 @@ class AlgoliaIndexer
      * Remove an item ID from the index. As this would usually be when an object
      * is deleted in Silverstripe we cannot rely on the object existing.
      *
-     * @param DataObject $item
+     * @param string $itemClass
+     * @param int $itemUUID
      */
-    public function deleteItem($item)
+    public function deleteItem($itemClass, $itemUUID)
     {
+        $item = DataObject::get_one($itemClass, ['AlgoliaUUID' => $itemUUID]);
+
         if (!$item || !$item->isInDB()) {
             return false;
         }

--- a/tests/AlgoliaIndexerTest.php
+++ b/tests/AlgoliaIndexerTest.php
@@ -36,4 +36,24 @@ class AlgoliaIndexerTest extends SapphireTest
         $this->assertArrayHasKey('objectID', $map);
         $this->assertEquals($map['objectTitle'], 'Foobar');
     }
+
+    public function testDeleteExistingItem()
+    {
+        $object = AlgoliaTestObject::create();
+        $object->Title = 'Delete This';
+        $object->write();
+
+        $indexer = Injector::inst()->get(AlgoliaIndexer::class);
+        $deleted = $indexer->deleteItem($object->getClassName(), $object->AlgoliaUUID);
+
+        return $this->assertTrue($deleted);
+    }
+
+    public function testDeleteNonExistentItem()
+    {
+        $indexer = Injector::inst()->get(AlgoliaIndexer::class);
+        $deleted = $indexer->deleteItem(AlgoliaTestObject::class, 9999999);
+
+        return $this->assertFalse($deleted);
+    }
 }


### PR DESCRIPTION
It doesn't look liked item deletion was updated to work with the UUID stuff. I added the class name of the object to remove to the `deleteItem` method and updated calling contexts.

I added a few tests to test the return value of the method. I wasn't sure of a good way to test the queue-related functionality, as I don't have a project handy for that, and there wasn't any testing infrastructure for that type of context.