### PR TITLE
Fix queuedjob index passing incorrect params since UUID change

### DIFF
--- a/src/Extensions/AlgoliaObjectExtension.php
+++ b/src/Extensions/AlgoliaObjectExtension.php
@@ -148,7 +148,7 @@ class AlgoliaObjectExtension extends DataExtension
         }
 
         if ($this->config()->get('use_queued_indexing')) {
-            $indexJob = new AlgoliaIndexItemJob($this->owner->AlgoliaUUID);
+            $indexJob = new AlgoliaIndexItemJob($this->owner->ClassName, $this->owner->ID);
             QueuedJobService::singleton()->queueJob($indexJob);
 
             return true;


### PR DESCRIPTION
Still needs ClassName to be able to look up.

Should this use UUID or just ID?
Could use UUID, will just need to change to `DataObject::get($this->itemClass, $uuid);` (and get the first only) when loading. Once it's loaded it uses the UUID for the actual delete command to Algolia.