### PR TITLE
Fix queuedjobs error re-instantiating delete job

### DIFF
--- a/src/Jobs/AlgoliaDeleteItemJob.php
+++ b/src/Jobs/AlgoliaDeleteItemJob.php
@@ -5,7 +5,6 @@ namespace Wilr\Silverstripe\Algolia\Jobs;
 use Exception;
 use Psr\Log\LoggerInterface;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\ORM\DataObject;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 use Symbiote\QueuedJobs\Services\QueuedJob;
 use Wilr\SilverStripe\Algolia\Service\AlgoliaIndexer;
@@ -20,7 +19,7 @@ class AlgoliaDeleteItemJob extends AbstractQueuedJob implements QueuedJob
      * @param string $itemClass
      * @param int    $itemUUID
      */
-    public function __construct($itemClass, $itemUUID)
+    public function __construct($itemClass = null, $itemUUID = null)
     {
         $this->itemClass = $itemClass;
         $this->itemUUID = $itemUUID;


### PR DESCRIPTION
I haven't dug into the queuedjobs module but I'm guessing when the job runs it creates a new instance, then rehydrates instance data from a cache. But it must call construct with no args. The error it was saying was
"Too few arguments to function Wilr\Silverstripe\Algolia\Jobs\AlgoliaDeleteItemJob::__construct(), 0 passed and exactly 2 expected"