### PR TITLE
Fix page duplication making records share UUID

### DIFF
--- a/src/Extensions/AlgoliaObjectExtension.php
+++ b/src/Extensions/AlgoliaObjectExtension.php
@@ -257,6 +257,16 @@ class AlgoliaObjectExtension extends DataExtension
     }
 
     /**
+     * Ensure each record has unique UUID
+     */
+    public function onBeforeDuplicate()
+    {
+        $this->owner->assignAlgoliaUUID();
+        $this->owner->AlgoliaIndexed = null;
+        $this->owner->AlgoliaError = null;
+    }
+
+    /**
      * @return array
      */
     public function getAlgoliaIndexes()


### PR DESCRIPTION
Pages that were cloned using the CMS duplicate feature were getting the same UUID, meaning the latest saved one would be in the index and others wouldn't.