### PR TITLE
Fix repeat reindexing causing duplicates/orphans

### DIFF
--- a/src/Extensions/AlgoliaObjectExtension.php
+++ b/src/Extensions/AlgoliaObjectExtension.php
@@ -126,11 +126,17 @@ class AlgoliaObjectExtension extends DataExtension
 
         if ($table) {
             $newValue = $isDeleted ? 'null' : 'NOW()';
+            // Also ensure Live and Draft UUIDs are the same in case Live didn't previously have a UUID
+            $uuid = "'" . $this->owner->AlgoliaUUID . "'";
             DB::query(sprintf("UPDATE %s SET AlgoliaIndexed = $newValue WHERE ID = %s", $table, $this->owner->ID));
 
             if ($this->owner->hasExtension('SilverStripe\Versioned\Versioned')) {
                 DB::query(
-                    sprintf("UPDATE %s_Live SET AlgoliaIndexed = $newValue WHERE ID = %s", $table, $this->owner->ID)
+                    sprintf(
+                        "UPDATE %s_Live SET AlgoliaIndexed = $newValue, AlgoliaUUID = $uuid WHERE ID = %s",
+                        $table,
+                        $this->owner->ID
+                    )
                 );
             }
         }


### PR DESCRIPTION
If the Live record doesn't have a UUID when you call reindex then it generates a new UUID but only saves it on the draft record. If you call reindex again it would regenerate a new UUID because it checks the Live version but doesn't write to Live.