### PR TITLE
Don't create a draft state when assigning a UUID

### DIFF
--- a/src/Jobs/AlgoliaIndexItemJob.php
+++ b/src/Jobs/AlgoliaIndexItemJob.php
@@ -98,7 +98,10 @@ class AlgoliaIndexItemJob extends AbstractQueuedJob implements QueuedJob
 
         $obj = DataObject::get_by_id($this->itemClass, $id);
 
-        if ($obj) {
+        if ($obj && $obj->canIndexInAlgolia()) {
+            if (!$obj->AlgoliaUUID) {
+                $obj->assignAlgoliaUUID();
+            }
             $obj->doImmediateIndexInAlgolia();
 
             unset($obj);

--- a/src/Jobs/AlgoliaReindexAllJob.php
+++ b/src/Jobs/AlgoliaReindexAllJob.php
@@ -2,7 +2,6 @@
 
 namespace Wilr\Silverstripe\Algolia\Jobs;
 
-use Exception;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataObject;
@@ -93,12 +92,6 @@ class AlgoliaReindexAllJob extends AbstractQueuedJob implements QueuedJob
         if ($obj && $obj->canIndexInAlgolia()) {
             if (!$obj->AlgoliaUUID) {
                 $obj->assignAlgoliaUUID();
-
-                try {
-                    $obj->write();
-                } catch (Exception $e) {
-                    Injector::inst()->get(LoggerInterface::class)->error($e);
-                }
             }
 
             if ($obj->AlgoliaUUID) {

--- a/src/Tasks/AlgoliaReindex.php
+++ b/src/Tasks/AlgoliaReindex.php
@@ -123,7 +123,6 @@ class AlgoliaReindex extends BuildTask
         $algoliaService = Injector::inst()->create(AlgoliaService::class);
         $count = 0;
         $skipped = 0;
-        $errored = 0;
         $total = ($items) ? $items->count() : 0;
         $batchSize = $this->config()->get('batch_size');
         $batchesTotal = ($total > 0) ? (ceil($total / $batchSize)) : 0;
@@ -171,16 +170,6 @@ class AlgoliaReindex extends BuildTask
                 // Set AlgoliaUUID, in case it wasn't previously set
                 if (!$item->AlgoliaUUID) {
                     $item->assignAlgoliaUUID();
-
-                    try {
-                        $item->write();
-                    } catch (Exception $e) {
-                        Injector::inst()->get(LoggerInterface::class)->error($e);
-
-                        $errored++;
-
-                        continue;
-                    }
                 }
 
                 $batchKey = get_class($item);
@@ -213,9 +202,8 @@ class AlgoliaReindex extends BuildTask
 
         Debug::message(
             sprintf(
-                "Number of objects indexed: %s, Errors: %s, Skipped %s",
+                "Number of objects indexed: %s, Skipped %s",
                 $count,
-                $errored,
                 $skipped
             )
         );


### PR DESCRIPTION
Otherwise when you first add this, or add a new versioned model to index, it sets all of those models in a modified state.

Also updated the AlgoliaReindex job to respect `canIndexInAlgolia` and still work if the item isn't yet indexed (instead of failing silently).