### PR TITLE
Use SS DataObject::get() rather then get_one()

### DIFF
--- a/src/Service/AlgoliaIndexer.php
+++ b/src/Service/AlgoliaIndexer.php
@@ -285,7 +285,7 @@ class AlgoliaIndexer
      */
     public function deleteItem($itemClass, $itemUUID)
     {
-        $item = DataObject::get_one($itemClass, ['AlgoliaUUID' => $itemUUID]);
+        $item = DataObject::get($itemClass)->find('AlgoliaUUID', $itemUUID);
 
         if (!$item || !$item->isInDB()) {
             return false;


### PR DESCRIPTION
Using get_one() is causing a SQL query error on filtering. Switching to using get() has resolved it by using silverstripe filter method.

Switching to using `DataObject::get()->find()` has resolved the issues and works in a similar way get_one() just without caching.

```
Couldn't run query:  SELECT DISTINCT "Element_Live"."ClassName", "Element_Live"."LastEdited", "Element_Live"."Created", "Element_Live"."Version", "Element_Live"."Title", "Element_Live"."ShowTitle", "Element_Live"."Sort", "Element_Live"."ExtraClass", "Element_Live"."Style", "Element_Live"."ParentID", "ElementContent_Live"."AlgoliaIndexed", "ElementContent_Live"."AlgoliaError", "ElementContent_Live"."AlgoliaUUID", "ElementContent_Live"."HTML", "Element_Live"."ID",  			CASE WHEN "Element_Live"."ClassName" IS NOT NULL THEN "Element_Live"."ClassName" 			ELSE 'DNADesign\\Elemental\\Models\\BaseElement' END AS "RecordClassName"  FROM "Element_Live" LEFT JOIN "ElementContent_Live" ON "ElementContent_Live"."ID" = "Element_Live"."ID"  WHERE (AlgoliaUUID = ?)  AND ("Element_Live"."ClassName" IN (?))  ORDER BY "Element_Live"."Sort" ASC  LIMIT 1  23000-1052: Column 'AlgoliaUUID' in where clause is ambiguous [] []
```