### PR TITLE
Add early return if no indexing

### DIFF
--- a/src/Extensions/AlgoliaObjectExtension.php
+++ b/src/Extensions/AlgoliaObjectExtension.php
@@ -98,6 +98,8 @@ class AlgoliaObjectExtension extends DataExtension
         $this->ranSync = true;
         $algolia = Injector::inst()->create(AlgoliaService::class);
 
+        if(!$this->indexEnabled()) return;
+
         try {
             $algolia->syncSettings();
         } catch (Throwable $e) {


### PR DESCRIPTION
I encountered an issue when running tests for some of my pages using fixture files. The extension tried to update indexes even though indexEnabled was set to false. 

This makes sure no indexing occurs in requireDefaultRecords if indexing is disabled.