### PR TITLE
fix: add new search client that uses the correct key

### DIFF
--- a/src/Service/AlgoliaQuerier.php
+++ b/src/Service/AlgoliaQuerier.php
@@ -48,7 +48,7 @@ class AlgoliaQuerier
 
         try {
             $selectedIndex = $service->environmentizeIndex($selectedIndex);
-            $index = $service->getClient()->initIndex($selectedIndex);
+            $index = $service->getSearchClient()->initIndex($selectedIndex);
             $results = $index->search($query, $searchParameters);
         } catch (Throwable $e) {
             Injector::inst()->get(LoggerInterface::class)->error($e);

--- a/src/Service/AlgoliaService.php
+++ b/src/Service/AlgoliaService.php
@@ -52,6 +52,28 @@ class AlgoliaService
         return $this->client;
     }
 
+    /**
+     * @return \Algolia\AlgoliaSearch\SearchClient
+     */
+    public function getSearchClient()
+    {
+        if (!$this->client) {
+            if (!$this->searchApiKey) {
+                throw new Exception('No searchApiKey configured for ' . self::class);
+            }
+
+            if (!$this->applicationId) {
+                throw new Exception('No applicationId configured for ' . self::class);
+            }
+
+            $this->client = SearchClient::create(
+                $this->applicationId,
+                $this->searchApiKey
+            );
+        }
+
+        return $this->client;
+    }
 
     public function getIndexes($excludeReplicas = true)
     {


### PR DESCRIPTION
The add the creation of a new Algolia SearchClient that will use the Search API key opposed to the Admin API key when searching. 
This resolves the issue https://github.com/wilr/silverstripe-algolia/issues/58
